### PR TITLE
#120 fix: show correct number of loans

### DIFF
--- a/containers/Dashboard/index.tsx
+++ b/containers/Dashboard/index.tsx
@@ -14,7 +14,7 @@ import { Graph, TimeSeriesData } from '../../components/Graph';
 import config from '../../config';
 
 const periodSelectionOptions = ['7d', '30d', '90d'];
-const defaultPeriodSelection = '7d';
+const defaultPeriodSelection = '90d';
 
 interface Props {
   tinlake: Tinlake;
@@ -163,6 +163,8 @@ class Dashboard extends React.Component<Props, State> {
       </Box>
 
       <LoanList tinlake={tinlake} mode="" />
+      <Box pad={{ horizontal: 'medium', vertical: 'medium' }}>
+      </Box>
     </Box>;
   }
 }

--- a/ducks/dashboard.ts
+++ b/ducks/dashboard.ts
@@ -1,5 +1,5 @@
 import { AnyAction, Action } from 'redux';
-import Tinlake from 'tinlake';
+import Tinlake, { Loan } from 'tinlake';
 import BN from 'bn.js';
 import { ThunkAction } from 'redux-thunk';
 
@@ -37,13 +37,15 @@ export default function reducer(state: DashboardState = initialState,
 export function getDashboardData(tinlake: Tinlake):
   ThunkAction<Promise<void>, DashboardState, undefined, Action> {
   return async (dispatch) => {
-    const loanCountPromise = tinlake.loanCount();
     const totalDebtPromise = tinlake.getTotalDebt();
     const totalBalancePromise = tinlake.getTotalBalance();
     const totalValueOfNFTsPromise = tinlake.getTotalValueOfNFTs();
 
+    const loans = await tinlake.getAllLoans();
+    const ongoingLoans = loans.filter( (l:Loan) => l.status === "Ongoing")
+
     const data = {
-      loanCount: await loanCountPromise,
+      loanCount: ongoingLoans && ongoingLoans.length || 0,
       totalDebt: await totalDebtPromise,
       totalBalance: await totalBalancePromise,
       totalValueOfNFTs: await totalValueOfNFTsPromise
@@ -60,7 +62,7 @@ export function subscribeDashboardData(tinlake: Tinlake):
 
     const interval = setInterval(
       () => dispatch(getDashboardData(tinlake)),
-      3600000
+      600000
     );
     const discard = () => clearInterval(interval);
     return discard as any;


### PR DESCRIPTION
- fix: just show number of ongoing loans instead of all loans in dashboard
- set graph period to 90 days per default
- add margin to dashboard bottom
