### PR TITLE
Replace header component with axis-nav-bar

### DIFF
--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -73,27 +73,23 @@ class Header extends React.Component<HeaderProps> {
 };
     return <ResponsiveContext.Consumer>{ size => size === "large" ? (
       <Box
-    justify="center"
     align="center"
     height="xsmall"
     fill="horizontal"
     style={{ position: 'sticky', top: 0, height: '90px', zIndex: 1 }}
     background="white"
     border={{ side: 'bottom', color: 'light-4' }}
+    direction="row"
+    justify="evenly"
+    pad={{ horizontal: 'medium' }}
+    gap={sectionGap}
+    width="xlarge"
   >
-    <Box
-      direction="row"
-      fill="vertical"
-      align="center"
-      justify="between"
-      pad={{ horizontal: 'medium' }}
-      gap={sectionGap}
-      width="xlarge"
-    >
+    <Box direction="row" align="center">
       <Link href="/">
         <a title="Tinlake"><Image src={logoUrl} style={{ width: 130 }} /></a>
       </Link>
-      {user && <Box fill={false}>
+      <Box fill={false}>
         <NavBar 
         border={false}
           theme={theme}
@@ -114,9 +110,9 @@ class Header extends React.Component<HeaderProps> {
             (item : MenuItem) => {
                 onRouteClick(item.route);
             }
-    }/></Box>}
-      { !user && <Button onClick={this.connectAccount} label="Connect" /> }
+    }/></Box></Box>
       <Box direction="row" gap="medium">
+      { !user && <Button onClick={this.connectAccount} label="Connect" /> }
       { user &&       
         <Box direction="row" gap={itemGap} align="center" justify="end">
         { isAdmin &&  <Badge text={'Admin'} /> }
@@ -136,7 +132,7 @@ class Header extends React.Component<HeaderProps> {
       <Anchor href="https://centrifuge.hackmd.io/zRnaoPqfS7mTm9XL0dDRtQ?view" target="blank" label="Help"  style={{ textDecoration: 'none', fontWeight: 900}} />
       }</Box>
     </Box>
-    </Box>)
+    )
     : 
     (<Box
     justify="center"

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Button, Image, Text, Anchor } from 'grommet';
+import { Box, Button, Image, Text, Anchor, ResponsiveContext } from 'grommet';
 import {Menu as MenuIcon, User as UserIcon, Close as CloseIcon} from "grommet-icons";
 import { connect } from 'react-redux';
 import Link from 'next/link';
@@ -71,7 +71,8 @@ class Header extends React.Component<HeaderProps> {
         }
     }
 };
-    return <Box
+    return <ResponsiveContext.Consumer>{ size => size === "large" ? (
+      <Box
     justify="center"
     align="center"
     height="xsmall"
@@ -92,7 +93,72 @@ class Header extends React.Component<HeaderProps> {
       <Link href="/">
         <a title="Tinlake"><Image src={logoUrl} style={{ width: 130 }} /></a>
       </Link>
-           
+      {user && <Box fill={false}>
+        <NavBar 
+        border={false}
+          theme={theme}
+          menuItems={menuItems.filter(item => 
+          {
+            return (
+              (user && isDemo ) ||
+              (user && isAdmin) && item.permission === "admin" ||
+              (user && !isAdmin) && item.permission === 'borrower' ||
+              !item.permission
+              ) 
+              && !item.secondary
+          }
+          )
+          } 
+          selectedRoute={selectedRoute} 
+          onRouteClick={
+            (item : MenuItem) => {
+                onRouteClick(item.route);
+            }
+    }/></Box>}
+      { !user && <Button onClick={this.connectAccount} label="Connect" /> }
+      <Box direction="row" gap="medium">
+      { user &&       
+        <Box direction="row" gap={itemGap} align="center" justify="end">
+        { isAdmin &&  <Badge text={'Admin'} /> }
+        </Box> 
+      }
+      { user && 
+        <Box direction="column">
+          <Box direction="row" gap={itemGap} align="center" justify="start">
+            <Text> { formatAddress(address || '') } </Text>
+          </Box>
+          <Box direction="row" justify="start" >
+            { network && <Text  style={{ color: '#808080' , lineHeight: '12px', fontSize: '12px' }}> Connected to {network} </Text> }
+          </Box>
+        </Box>
+      }
+      { isDemo && 
+      <Anchor href="https://centrifuge.hackmd.io/zRnaoPqfS7mTm9XL0dDRtQ?view" target="blank" label="Help"  style={{ textDecoration: 'none', fontWeight: 900}} />
+      }</Box>
+    </Box>
+    </Box>)
+    : 
+    (<Box
+    justify="center"
+    align="center"
+    height="xsmall"
+    fill="horizontal"
+    style={{ position: 'sticky', top: 0, height: '90px', zIndex: 1 }}
+    background="white"
+    border={{ side: 'bottom', color: 'light-4' }}
+  >
+    <Box
+      direction="row"
+      fill="vertical"
+      align="center"
+      justify="between"
+      pad={{ horizontal: 'medium' }}
+      gap={sectionGap}
+      width="xlarge"
+    >
+      <Link href="/">
+        <a title="Tinlake"><Image src={logoUrl} style={{ width: 130 }} /></a>
+      </Link>
       { !user && <Button onClick={this.connectAccount} label="Connect" /> }
       { user &&       
         <Box direction="row" gap={itemGap} align="center" justify="end">
@@ -135,7 +201,8 @@ class Header extends React.Component<HeaderProps> {
             }
     }/></Box>}
     </Box>
-    </Box>
+    
+    </Box>)}</ResponsiveContext.Consumer>
 
   }
 }

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -92,8 +92,7 @@ class Header extends React.Component<HeaderProps> {
       <Link href="/">
         <a title="Tinlake"><Image src={logoUrl} style={{ width: 130 }} /></a>
       </Link>
-
-      
+           
       { !user && <Button onClick={this.connectAccount} label="Connect" /> }
       { user &&       
         <Box direction="row" gap={itemGap} align="center" justify="end">
@@ -113,27 +112,29 @@ class Header extends React.Component<HeaderProps> {
       { isDemo && 
       <Anchor href="https://centrifuge.hackmd.io/zRnaoPqfS7mTm9XL0dDRtQ?view" target="blank" label="Help"  style={{ textDecoration: 'none', fontWeight: 900}} />
       }
-    </Box>
-    <NavBar 
-      theme={theme}
-        menuItems={menuItems.filter(item => 
-        {
-          return (
-            (user && isDemo ) ||
-            (user && isAdmin) && item.permission === "admin" ||
-            (user && !isAdmin) && item.permission === 'borrower' ||
-            !item.permission
-            ) 
-            && !item.secondary
-        }
-        )
-        } 
-        selectedRoute={selectedRoute} 
-        onRouteClick={
-          (item : MenuItem) => {
-              onRouteClick(item.route);
+      {user && <Box fill={false}>
+        <NavBar 
+        border={false}
+          theme={theme}
+          menuItems={menuItems.filter(item => 
+          {
+            return (
+              (user && isDemo ) ||
+              (user && isAdmin) && item.permission === "admin" ||
+              (user && !isAdmin) && item.permission === 'borrower' ||
+              !item.permission
+              ) 
+              && !item.secondary
           }
-  }/>
+          )
+          } 
+          selectedRoute={selectedRoute} 
+          onRouteClick={
+            (item : MenuItem) => {
+                onRouteClick(item.route);
+            }
+    }/></Box>}
+    </Box>
     </Box>
 
   }

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import { Box, Button, Image, Text, Anchor } from 'grommet';
+import {Menu as MenuIcon, User as UserIcon, Close as CloseIcon} from "grommet-icons";
 import { connect } from 'react-redux';
 import Link from 'next/link';
+import Router from 'next/router';
 import { AuthState } from '../../ducks/auth';
 import Badge from '../Badge';
 import { formatAddress } from '../../utils/formatAddress';
 import config from '../../config'
 import { authTinlake } from '../../services/tinlake';
+
+import { NavBar } from "./navbar";
+//import { NavBar } from "@centrifuge/axis-nav-bar";
+
 
 const { isDemo } = config
 export interface MenuItem {
@@ -24,6 +30,12 @@ interface HeaderProps {
 
 class Header extends React.Component<HeaderProps> {
 
+  constructor(props: HeaderProps) {
+    super(props);
+    this.state = {
+      chosenRoute: '/'
+    };
+  }
   connectAccount = async () => {
     try {
       await authTinlake();
@@ -42,6 +54,23 @@ class Header extends React.Component<HeaderProps> {
     const itemGap = 'small';
     const logoUrl = isDemo && "/static/demo_logo.svg" || "/static/logo.svg";
 
+    const onRouteClick = (route: string ) => {
+      this.setState({chosenRoute :route});
+      if (route.startsWith('/')) {
+          Router.push(route);
+      } else {
+          window.open(route);
+      }
+  };
+  const theme = {
+    navBar: {
+        icons: {
+            menu: MenuIcon,
+            close: CloseIcon,
+            user: UserIcon
+        }
+    }
+};
     return <Box
     justify="center"
     align="center"
@@ -63,34 +92,10 @@ class Header extends React.Component<HeaderProps> {
       <Link href="/">
         <a title="Tinlake"><Image src={logoUrl} style={{ width: 130 }} /></a>
       </Link>
-      <Box direction="row" gap={itemGap} margin={{ right: 'auto' }}>
 
-        {menuItems.filter(item => 
-        {
-          return (
-            (user && isDemo ) ||
-            (user && isAdmin) && item.permission === "admin" ||
-            (user && !isAdmin) && item.permission === 'borrower' ||
-            !item.permission
-            ) 
-            && !item.secondary
-        }
-        )
-        .map((item) => {
-          const anchorProps = {
-            ...(item.route === selectedRoute ?
-              { className: 'selected', color: '#0828BE' } : {}),
-          };
-          return <Link href={item.route} key={item.label}><Button
-            plain
-            label={item.label}
-            {...anchorProps}
-          /></Link>;
-        },
-        )}
-      </Box>
+      
       { !user && <Button onClick={this.connectAccount} label="Connect" /> }
-      { user && 
+      { user &&       
         <Box direction="row" gap={itemGap} align="center" justify="end">
         { isAdmin &&  <Badge text={'Admin'} style={{  }} /> }
         </Box> 
@@ -106,10 +111,31 @@ class Header extends React.Component<HeaderProps> {
         </Box>
       }
       { isDemo && 
-      <Anchor href="https://centrifuge.hackmd.io/zRnaoPqfS7mTm9XL0dDRtQ?view" primary target="blank" label="Help"  style={{ textDecoration: 'none', fontWeight: 900}} />
+      <Anchor href="https://centrifuge.hackmd.io/zRnaoPqfS7mTm9XL0dDRtQ?view" target="blank" label="Help"  style={{ textDecoration: 'none', fontWeight: 900}} />
       }
     </Box>
-  </Box>;
+    <NavBar 
+      theme={theme}
+        menuItems={menuItems.filter(item => 
+        {
+          return (
+            (user && isDemo ) ||
+            (user && isAdmin) && item.permission === "admin" ||
+            (user && !isAdmin) && item.permission === 'borrower' ||
+            !item.permission
+            ) 
+            && !item.secondary
+        }
+        )
+        } 
+        selectedRoute={selectedRoute} 
+        onRouteClick={
+          (item : MenuItem) => {
+              onRouteClick(item.route);
+          }
+  }/>
+    </Box>
+
   }
 }
 

--- a/components/Header/navbar/NavBar.test.tsx
+++ b/components/Header/navbar/NavBar.test.tsx
@@ -1,0 +1,3 @@
+describe("Nav Bar test", () => {
+  it("needs tests", () => {});
+});

--- a/components/Header/navbar/NavBar.tsx
+++ b/components/Header/navbar/NavBar.tsx
@@ -1,0 +1,263 @@
+import React, {FunctionComponent, useState} from 'react';
+import {Anchor, Box, BoxProps, Button, Layer, Menu, ResponsiveContext, Text} from 'grommet';
+import {Close as CloseIcon, Icon, Menu as MenuIcon, User as UserIcon} from 'grommet-icons';
+import styled, {ThemeProps as StyledThemeProps, withTheme} from 'styled-components';
+import {defaultProps, extendDefaultTheme} from "grommet/default-props";
+
+
+// Define type for theme props
+interface ThemeProps {
+  navBar: {
+    icons: {
+      menu: Icon,
+      close: Icon,
+      user: Icon,
+      size?: "small" | "medium" | "large" | "xlarge" | string;
+    }
+  }
+}
+
+const defaultThemeProps: ThemeProps = {
+  navBar: {
+
+    icons: {
+      menu: MenuIcon,
+      close: CloseIcon,
+      user: UserIcon
+    }
+  }
+};
+
+
+export interface MenuItem {
+  label: string,
+  route: string,
+  secondary?: boolean
+}
+
+interface Props extends BoxProps, StyledThemeProps<ThemeProps> {
+  logo?: React.ReactNode,
+  menuLabel?: string,
+  selectedRoute: string,
+  sectionGap?: string,
+  itemGap?: string,
+  mainMenuAlignment?: 'right' | 'left',
+  sticky?: boolean,
+  menuItems: MenuItem[],
+  onRouteClick: (item: MenuItem) => void,
+}
+
+
+const StyledNavBar = styled(Box)<{
+  sticky: boolean | undefined
+}>`
+  ${props => props.sticky && `
+    position: sticky;
+    z-index: 1;
+    top:0px;
+  `}
+`;
+
+
+const NavBar: FunctionComponent<Props> = (props) => {
+
+  const {
+    logo,
+    selectedRoute,
+    sectionGap,
+    itemGap,
+    menuItems,
+    onRouteClick,
+    sticky,
+    width,
+    pad,
+    menuLabel,
+    mainMenuAlignment,
+    theme,
+    children,
+    ...rest
+  } = props;
+
+
+  const [opened, setOpened] = useState(false);
+  const openMenu = () => setOpened(true);
+  const closeMenu = () => setOpened(false);
+
+
+  //get the icons from the theme
+  const {navBar: {icons}} = theme;
+
+  // Workaround for Menu typescript def bug
+  const DynamicPropsMenu: any = Menu;
+
+
+  const getMainMenuItems = () => {
+    return menuItems.filter(item => !item.secondary).map((item) => {
+        const anchorProps = {
+          ...{onClick: () => onRouteClick(item)},
+          ...(selectedRoute === item.route ? {color: 'selected'} : {}),
+        };
+
+
+        return <Button
+          plain
+          key={item.label}
+          label={item.label}
+          {...anchorProps}
+        />;
+      },
+    );
+  };
+
+
+  const getSecondaryMenuItems = () => {
+    return menuItems.filter(item => item.secondary).map((item) => {
+        const anchorProps = {
+          ...{onClick: () => onRouteClick(item)},
+          ...(selectedRoute === item.route ? {className: 'selected'} : {}),
+        };
+        return <Anchor
+          key={item.label}
+          label={item.label}
+          {...anchorProps}
+        />;
+      },
+    );
+  };
+
+  return (<StyledNavBar
+    {...rest}
+    sticky={sticky}
+    justify="center"
+    align="center"
+    fill="horizontal"
+
+  >
+    <ResponsiveContext.Consumer>
+      {size => {
+
+        const isSmall = size === 'small';
+        const isMedium = size === 'medium';
+        const isMobile = isSmall || isMedium;
+
+
+        return <Box
+          direction="row"
+          fill="vertical"
+          align="center"
+          pad={pad}
+          gap={sectionGap}
+          width={width}
+        >
+
+          {logo && <Box>
+            {logo}
+          </Box>}
+
+          <Box flex={'grow'} direction="row" justify={'end'} gap={sectionGap}>
+            {!isMobile && <Box direction="row" gap={itemGap}>
+              {getMainMenuItems()}
+            </Box>}
+            {(!isMobile) && <Box flex={mainMenuAlignment === 'left' ? 'grow' : false} justify={'center'}>
+              {children}
+            </Box>}
+            {(!menuLabel ?
+              !isMobile && <Box direction="row" gap={itemGap} align="center" justify="end">
+                {getSecondaryMenuItems()}
+              </Box>
+              :
+              !isSmall && <DynamicPropsMenu
+                plain
+                items={
+                  menuItems.filter(item => item.secondary).map((item) => {
+                      return {label: item.label, onClick: () => onRouteClick(item)};
+                    },
+                  )
+                }
+              >
+                {({drop, hover}) => {
+
+                  return (
+                    <Box
+                      direction="row"
+                      gap="small"
+                      pad={'small'}
+                      background={hover && drop ? 'light-2' : undefined}
+                    >
+                      <Text>{menuLabel}</Text>
+                      <icons.user size={icons.size}/>
+                    </Box>
+                  );
+                }}
+              </DynamicPropsMenu>)
+            }
+
+            {isMobile && (
+              <Box direction="row" align="center">
+                <Anchor>
+                  <icons.menu size={icons.size} onClick={openMenu}/>
+                </Anchor>
+              </Box>
+
+            )}
+
+
+          </Box>
+          {(opened && isMobile) && (
+            <Layer
+              position="right"
+              full="vertical"
+              responsive={false}
+              animate={true}
+              onClickOutside={closeMenu}
+              onEsc={closeMenu}
+            >
+              <Box width={'100vw'} pad={{"top":'medium'}}>
+                <Box fill={'horizontal'} align={'end'}>
+                  <Anchor onClick={closeMenu}>
+                    <icons.close size={icons.size}/>
+                  </Anchor>
+
+                </Box>
+                <Box gap={sectionGap}>
+                  <Box gap={itemGap}>
+                    {getMainMenuItems()}
+                  </Box>
+
+                  {((menuLabel && isSmall) || (isMobile && !menuLabel)) &&
+                  <Box gap={itemGap} align={'center'}>
+                    {getSecondaryMenuItems()}
+                  </Box>
+                  }
+                </Box>
+
+              </Box>
+
+            </Layer>)
+          }
+        </Box>;
+      }}
+
+
+    </ResponsiveContext.Consumer>
+
+  </StyledNavBar>)
+};
+
+
+extendDefaultTheme(defaultThemeProps);
+
+NavBar.defaultProps = {
+  sectionGap: 'large',
+  itemGap: 'medium',
+  sticky: true,
+  pad: {horizontal: 'medium'},
+  width: '100%',
+  background: 'white',
+  mainMenuAlignment: 'left',
+  height: '72px',
+  border: {side: 'bottom', color: 'light-4'},
+  ...defaultProps
+};
+
+export default withTheme(NavBar)

--- a/components/Header/navbar/index.ts
+++ b/components/Header/navbar/index.ts
@@ -1,0 +1,5 @@
+import NavBar  from "./NavBar";
+
+export  {
+  NavBar
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/centrifuge/tinlake-ui#readme",
   "dependencies": {
     "@centrifuge/axis-display-field": "^0.3.2-develop.51",
+    "@centrifuge/axis-nav-bar": "^0.3.2-develop.47",
     "@centrifuge/axis-spinner": "^0.3.1",
     "@centrifuge/axis-theme": "^0.2.1-develop.33",
     "@centrifuge/axis-utils": "^0.3.2-develop.49",


### PR DESCRIPTION
Second PR related to [Developer.Centrifuge.io issue #129](https://github.com/centrifuge/developer.centrifuge.io/issues/129)  

Replaces the custom coded header navigation with the [@centrifuge/axis-nav-bar](https://github.com/centrifuge/axis-nav-bar) component