### PR TITLE
fix: get tranche total reserve

### DIFF
--- a/containers/Investment/Redeem/index.tsx
+++ b/containers/Investment/Redeem/index.tsx
@@ -80,7 +80,7 @@ class InvestorRedeem extends React.Component<Props, State> {
             Max redeem amount exceeded.   <br /> 
             Amount has to be lower then <br />
             <Text weight="bold">
-              {`${maxRedeemAmount.toString()}`}
+              {`${baseToDisplay(maxRedeemAmount, 18)}`}
             </Text>
           </Box>
         }
@@ -90,7 +90,7 @@ class InvestorRedeem extends React.Component<Props, State> {
             Available token amount exceeded.   <br /> 
             Amount has to be lower then <br />
             <Text weight="bold">
-              {`${juniorTokenBalance.toString()}`}
+              {`${baseToDisplay(juniorTokenBalance, 18)}`}
             </Text>
           </Box>
         }

--- a/containers/Loan/Borrow/index.tsx
+++ b/containers/Loan/Borrow/index.tsx
@@ -27,9 +27,9 @@ interface State {
 class LoanBorrow extends React.Component<Props, State> {
 
   componentWillMount() {
-    const { loan } = this.props;
+    const { loan, tinlake, loadAnalyticsData } = this.props;
     this.setState({ borrowAmount: (loan.principal || '0') });
-    loadAnalyticsData && loadAnalyticsData(this.props.tinlake);
+    loadAnalyticsData && loadAnalyticsData(tinlake);
   }
 
   borrow = async () => {
@@ -76,7 +76,7 @@ class LoanBorrow extends React.Component<Props, State> {
              Available funds exceeded. <br /> 
              Amount has to be lower then <br />
              <Text weight="bold">
-              {`${availableFunds.toString()}`}
+              {`${baseToDisplay(availableFunds, 18)}`}
              </Text>
            </Box>
            }
@@ -85,7 +85,7 @@ class LoanBorrow extends React.Component<Props, State> {
             Max borrow amount exceeded.   <br /> 
             Amount has to be lower then <br />
             <Text weight="bold">
-              {`${loan.principal.toString()}`}
+              {`${baseToDisplay(loan.principal, 18)}`}
             </Text>
           </Box>
         }

--- a/containers/Loan/Issue/index.tsx
+++ b/containers/Loan/Issue/index.tsx
@@ -89,8 +89,6 @@ class IssueLoan extends React.Component<Props, State> {
         :
         <Box>
         <Box>
-          {is === 'success' && <Alert type="success">
-            Successfully opened loan for Token ID {tokenId}</Alert>}
           {is === 'error' && <Alert type="error">
             <Text weight="bold">
               Error opening loan for Token ID {tokenId}, see console for details</Text>

--- a/containers/Loan/View/index.tsx
+++ b/containers/Loan/View/index.tsx
@@ -27,7 +27,8 @@ interface Props {
 class LoanView extends React.Component<Props> {
 
   componentWillMount() {
-    this.props.loanId && this.props.loadLoan!(this.props.tinlake, this.props.loanId);
+    const { tinlake, loanId } = this.props;
+    this.props.loanId && this.props.loadLoan!(tinlake, loanId);
     this.props.resetTransactionState && this.props.resetTransactionState();
   }
 

--- a/ducks/analytics.ts
+++ b/ducks/analytics.ts
@@ -1,6 +1,7 @@
 import { AnyAction, Action } from 'redux';
 import { ThunkAction } from 'redux-thunk';
-import { getAnalytics, TinlakeResult, Tranche } from '../services/tinlake/actions'
+import { getAnalytics, TinlakeResult } from '../services/tinlake/actions'
+import { Tranche } from 'tinlake';
 
 // Actions
 const LOAD_ANALYTICS = 'tinlake-ui/analytics/LOAD_ANALYTICS';

--- a/services/tinlake/actions.ts
+++ b/services/tinlake/actions.ts
@@ -1,5 +1,5 @@
 import BN from 'bn.js';
-import { Loan, Investor, NFT, interestRateToFee } from 'tinlake';
+import { Loan, Investor, Tranche, NFT, interestRateToFee } from 'tinlake';
 import config from '../../config';
 
 const { contractAddresses } = config;
@@ -215,7 +215,9 @@ export async function borrow(tinlake: any, loan: Loan, amount: string) {
   const proxy = loan.ownerOf;
 
   // make sure tranche has enough funds
-  const trancheReserve = await tinlake.getTrancheBalance();
+  const juniorReserve = await tinlake.getJuniorReserve();
+  const seniorReserve = await tinlake.getSeniorReserve();
+  const trancheReserve = juniorReserve.add(seniorReserve);
   if(new BN(amount).cmp(trancheReserve) > 0) {
     return loggedError({},'There is not enough available funds.', loanId);
   }


### PR DESCRIPTION
- fix getTrancheTotalReserve: add junior & senior
-properly format values in warning messages for borrow & redeeem
- fix: load recent analytics state when accessing loan through deep link