### PR TITLE
Refactor auth state to make more robust

### DIFF
--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -56,7 +56,8 @@ class Header extends React.Component<HeaderProps, State> {
   pushWithPrefixIfInPool = (item: MenuItem) => {
     if (item.inPool) {
       const { root } = this.props.router.query;
-      Router.push(`/[root]${item.route}`, `/${root}${item.route}`);
+      const route = item.route === '/' ? '' : item.route;
+      Router.push(`/[root]${route}`, `/${root}${route}`);
       return;
     }
     Router.push(item.route);
@@ -64,9 +65,8 @@ class Header extends React.Component<HeaderProps, State> {
 
   render() {
     const { poolTitle, selectedRoute, menuItems, auth } = this.props;
-    const user = auth && auth.user;
-    const address = user && user.address;
-    const network = auth && auth.network;
+    const address = auth?.address;
+    const network = auth?.network;
 
     const itemGap = 'small';
     const logoUrl = isDemo && '/static/demo_logo.svg' || '/static/logo.svg';
@@ -118,12 +118,12 @@ class Header extends React.Component<HeaderProps, State> {
             </Box>
           </Box>
           <Box direction="row" basis="full">
-            {!user &&
+            {!address &&
               <Box direction="column" align="end" basis="full" alignSelf="center">
                 <Button onClick={this.connectAccount} label="Connect" />
               </Box>
             }
-            {user &&
+            {address &&
               <Box direction="column" align="end" basis="full">
                 <Box direction="row" gap={itemGap} align="center" justify="start">
                   <Text> {formatAddress(address || '')} </Text>
@@ -147,12 +147,12 @@ class Header extends React.Component<HeaderProps, State> {
             </Box>
             <Box flex="grow" basis="auto" style={{ fontSize: 16, fontWeight: 500 }}>{poolTitle}</Box>
             <Box direction="row" basis="full" >
-            {!user &&
+            {!address &&
               <Box direction="column" align="end" basis="full" alignSelf="center">
                 <Button onClick={this.connectAccount} label="Connect" />
               </Box>
             }
-            {user &&
+            {address &&
             <Box direction="column" align="end" basis="full" alignSelf="center">
               <Box direction="row" gap={itemGap} align="center" justify="start">
                 <Text> {formatAddress(address || '')} </Text>

--- a/components/WithTinlake/index.tsx
+++ b/components/WithTinlake/index.tsx
@@ -33,6 +33,8 @@ class WithTinlake extends React.Component<Props, State> {
   }
 
   init = async () => {
+    console.log('components/WithTinlake init');
+
     const { addresses, contractConfig } = this.props;
 
     this.tinlake = await getTinlake({ addresses, contractConfig });

--- a/containers/Investment/Tranche/index.tsx
+++ b/containers/Investment/Tranche/index.tsx
@@ -24,9 +24,9 @@ class TrancheView extends React.Component<Props> {
 
   render() {
     const { auth, investor, transactions, tranche, tinlake } = this.props;
-    const isAdmin = (tranche.type === 'junior') && auth.user && auth.user.permissions.canSetInvestorAllowanceJunior
-      || (tranche.type === 'senior') && auth.user && auth.user.permissions.canSetInvestorAllowanceSenior;
-    const isInvestor = (auth.user && investor) && (auth.user.address.toLowerCase() === investor.address.toLowerCase());
+    const isAdmin = (tranche.type === 'junior') && auth.permissions?.canSetInvestorAllowanceJunior
+      || (tranche.type === 'senior') && auth.permissions?.canSetInvestorAllowanceSenior;
+    const isInvestor = investor && (auth.address?.toLowerCase() === investor.address.toLowerCase());
     if (transactions && transactions.transactionState && transactions.transactionState === 'processing') {
       return <Spinner height={'calc(100vh - 89px - 84px)'} message={transactions.loadingMessage ||
         'Processing Transaction. This may take a fev seconds. Please wait...'} />;

--- a/containers/Investment/View/index.tsx
+++ b/containers/Investment/View/index.tsx
@@ -49,7 +49,7 @@ class InvestmentsView extends React.Component<Props, State> {
 
     return <Box>
 
-      {pool && pool.data && <Box margin={{ bottom: 'medium' }}> <InvestmentsOverview data={pool && pool.data} /> </Box>}
+      {pool?.data && <Box margin={{ bottom: 'medium' }}> <InvestmentsOverview data={pool?.data} /> </Box>}
 
       {transactions && transactions.errorMessage &&
         <Box pad={{ horizontal: 'medium' }} margin={{ bottom: 'small' }}>
@@ -58,7 +58,7 @@ class InvestmentsView extends React.Component<Props, State> {
           </Alert>
         </Box>}
 
-      {pool && pool.data && auth && auth.user && auth.user.permissions.canSetMinimumJuniorRatio &&
+      {pool?.data && auth.permissions?.canSetMinimumJuniorRatio &&
         <JuniorRatio tinlake={tinlake} minJuniorRatio={pool.data.minJuniorRatio} />
       }
 

--- a/containers/Loan/Issue/index.tsx
+++ b/containers/Loan/Issue/index.tsx
@@ -7,7 +7,7 @@ import { getNFT, issue, TinlakeResult } from '../../../services/tinlake/actions'
 import { authTinlake } from '../../../services/tinlake';
 import { Spinner } from '@centrifuge/axis-spinner';
 import LoanView from '../View';
-import { AuthState, loadUserProxies } from '../../../ducks/auth';
+import { AuthState, loadProxies } from '../../../ducks/auth';
 import { NFT } from 'tinlake';
 
 interface Props {
@@ -15,7 +15,7 @@ interface Props {
   tokenId: string;
   registry: string;
   auth: AuthState;
-  loadUserProxies?: () => Promise<void>;
+  loadProxies?: () => Promise<void>;
 }
 
 interface State {
@@ -42,7 +42,7 @@ class IssueLoan extends React.Component<Props, State> {
   // handlers
   onTokenIdValueChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const currentTokenId = event.currentTarget.value;
-    await this.setState({
+    this.setState({
       tokenId: currentTokenId,
       nft: null,
       nftError: ''
@@ -52,7 +52,7 @@ class IssueLoan extends React.Component<Props, State> {
 
   onRegistryAddressValueChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const currentRegistryAddress = event.currentTarget.value;
-    await this.setState({
+    this.setState({
       registry: currentRegistryAddress,
       nft: null,
       nftError: ''
@@ -79,7 +79,7 @@ class IssueLoan extends React.Component<Props, State> {
   }
 
   issueLoan = async () => {
-    const { tinlake, loadUserProxies } = this.props;
+    const { tinlake, loadProxies } = this.props;
     const { tokenId } = this.state;
     this.setState({ is: 'loading' });
 
@@ -95,7 +95,7 @@ class IssueLoan extends React.Component<Props, State> {
       const loanId = result.data;
       this.setState({ loanId });
       this.setState({ is: 'success' });
-      loadUserProxies && loadUserProxies();
+      loadProxies && loadProxies();
     } catch (e) {
       this.setState({ is: 'error', errorMsg: e.message });
     }
@@ -176,4 +176,4 @@ class IssueLoan extends React.Component<Props, State> {
   }
 }
 
-export default connect(state => state, { loadUserProxies })(IssueLoan);
+export default connect(state => state, { loadProxies })(IssueLoan);

--- a/containers/Loan/List/index.tsx
+++ b/containers/Loan/List/index.tsx
@@ -5,7 +5,7 @@ import { LoansState, loadLoans } from '../../../ducks/loans';
 import { PoolState, loadPool } from '../../../ducks/pool';
 import { baseToDisplay } from 'tinlake';
 import { Spinner } from '@centrifuge/axis-spinner';
-import { AuthState, loadUserProxies } from '../../../ducks/auth';
+import { AuthState } from '../../../ducks/auth';
 import LoanListData from '../../../components/Loan/List';
 import NumberDisplay from '../../../components/NumberDisplay';
 import DashboardMetric from '../../../components/DashboardMetric';
@@ -46,4 +46,4 @@ class LoanList extends React.Component<Props> {
   }
 }
 
-export default connect(state => state, { loadLoans, loadPool, loadUserProxies })(LoanList);
+export default connect(state => state, { loadLoans, loadPool })(LoanList);

--- a/containers/Loan/View/index.tsx
+++ b/containers/Loan/View/index.tsx
@@ -8,7 +8,7 @@ import LoanBorrow from '../Borrow';
 import LoanRepay from '../Repay';
 import { Spinner } from '@centrifuge/axis-spinner';
 import NftData from '../../../components/NftData';
-import { AuthState, loadUserProxies } from '../../../ducks/auth';
+import { AuthState, loadProxies } from '../../../ducks/auth';
 import { TransactionState, resetTransactionState } from '../../../ducks/transactions';
 
 interface Props {
@@ -19,17 +19,17 @@ interface Props {
   auth?: AuthState;
   transactions?: TransactionState;
   resetTransactionState?: () => void;
-  loadUserProxies?: () => Promise<void>;
+  loadProxies?: () => Promise<void>;
 }
 
 // on state change tokenId --> load nft data for loan collateral
 class LoanView extends React.Component<Props> {
 
   componentDidMount() {
-    const { tinlake, loanId, loadLoan, resetTransactionState, loadUserProxies } = this.props;
+    const { tinlake, loanId, loadLoan, resetTransactionState, loadProxies } = this.props;
     loanId && loadLoan!(tinlake, loanId);
     resetTransactionState && resetTransactionState();
-    loadUserProxies && loadUserProxies();
+    loadProxies && loadProxies();
   }
 
   componentWillUnmount() {
@@ -45,8 +45,7 @@ class LoanView extends React.Component<Props> {
         Could not find loan {loanId}</Alert>;
     }
 
-    const user = auth && auth.user;
-    const hasBorrowerPermissions =  user && loan && (user.proxies.includes(loan.ownerOf.toString()));
+    const hasBorrowerPermissions = loan && auth?.proxies?.includes(loan.ownerOf.toString());
     if (transactions && transactions.transactionState && transactions.transactionState === 'processing') {
       return <Spinner height={'calc(100vh - 89px - 84px)'} message={transactions.loadingMessage ||
         'Processing Transaction. This may take a few seconds. Please wait...'} />;
@@ -87,4 +86,4 @@ class LoanView extends React.Component<Props> {
   }
 }
 
-export default connect(state => state, { loadLoan, resetTransactionState, loadUserProxies })(LoanView);
+export default connect(state => state, { loadLoan, resetTransactionState, loadProxies })(LoanView);

--- a/containers/Overview/index.tsx
+++ b/containers/Overview/index.tsx
@@ -35,7 +35,7 @@ class Overview extends React.Component<Props> {
 
   render() {
     const { tinlake, loans, auth, selectedPool, pool } = this.props;
-    const userAddress = auth && auth.user && auth.user.address || tinlake.ethConfig.from;
+    const userAddress = auth?.address || tinlake.ethConfig.from;
 
     const { name, description } = selectedPool;
     const allLoans = loans && loans.loans || [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -7751,7 +7751,7 @@
       "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
     },
     "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#8431eab7b3384e65e8126a4602520b78031666fb",
+      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
       "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
       "requires": {
         "bn.js": "^4.11.8",
@@ -8846,25 +8846,25 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "optional": true,
           "requires": {
@@ -8874,13 +8874,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "optional": true,
           "requires": {
@@ -8890,37 +8890,37 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "optional": true,
           "requires": {
@@ -8929,25 +8929,25 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "optional": true,
           "requires": {
@@ -8956,13 +8956,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
@@ -8978,7 +8978,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "optional": true,
           "requires": {
@@ -8992,13 +8992,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "optional": true,
           "requires": {
@@ -9007,7 +9007,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "optional": true,
           "requires": {
@@ -9016,7 +9016,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
@@ -9026,19 +9026,19 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "optional": true,
           "requires": {
@@ -9047,13 +9047,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "optional": true,
           "requires": {
@@ -9062,13 +9062,13 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "optional": true,
           "requires": {
@@ -9078,7 +9078,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "optional": true,
           "requires": {
@@ -9087,7 +9087,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "optional": true,
           "requires": {
@@ -9096,13 +9096,13 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
           "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "optional": true,
           "requires": {
@@ -9113,7 +9113,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "optional": true,
           "requires": {
@@ -9131,7 +9131,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
@@ -9141,13 +9141,13 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "optional": true,
           "requires": {
@@ -9157,7 +9157,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "optional": true,
           "requires": {
@@ -9169,19 +9169,19 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "optional": true,
           "requires": {
@@ -9190,19 +9190,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
@@ -9212,19 +9212,19 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "optional": true,
           "requires": {
@@ -9236,7 +9236,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
@@ -9244,7 +9244,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "optional": true,
           "requires": {
@@ -9259,7 +9259,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "optional": true,
           "requires": {
@@ -9268,43 +9268,43 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "optional": true,
           "requires": {
@@ -9315,7 +9315,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
@@ -9324,7 +9324,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "optional": true,
           "requires": {
@@ -9333,13 +9333,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "optional": true,
           "requires": {
@@ -9354,13 +9354,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "optional": true,
           "requires": {
@@ -9369,13 +9369,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "optional": true
         }
@@ -15755,8 +15755,8 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
     "tinlake": {
-      "version": "github:centrifuge/tinlake.js#80206491d18610e90f20d0a8c556ff5329891835",
-      "from": "github:centrifuge/tinlake.js#80206491d18610e90f20d0a8c556ff5329891835",
+      "version": "github:centrifuge/tinlake.js#77d27e3837303332e47ffb6fd2773663060e7b19",
+      "from": "github:centrifuge/tinlake.js#77d27e3837303332e47ffb6fd2773663060e7b19",
       "requires": {
         "bignumber.js": "^9.0.0",
         "decimal.js-light": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "styled-components": "^5.1.0",
-    "tinlake": "github:centrifuge/tinlake.js#80206491d18610e90f20d0a8c556ff5329891835",
+    "tinlake": "github:centrifuge/tinlake.js#77d27e3837303332e47ffb6fd2773663060e7b19",
     "web3-utils": "^1.2.7",
     "web3connect": "^1.0.0-beta.13",
     "yup": "^0.28.5"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "styled-components": "^5.1.0",
-    "tinlake": "github:centrifuge/tinlake.js#77d27e3837303332e47ffb6fd2773663060e7b19",
+    "tinlake": "github:centrifuge/tinlake.js#0ab9e8d40ef324c60ac484d9fe460a0afaa33a96",
     "web3-utils": "^1.2.7",
     "web3connect": "^1.0.0-beta.13",
     "yup": "^0.28.5"

--- a/pages/[root]/demo/mint-nft.tsx
+++ b/pages/[root]/demo/mint-nft.tsx
@@ -8,6 +8,7 @@ import ContainerWithFooter from '../../../components/ContainerWithFooter';
 import config, { Pool } from '../../../config';
 import { WithRouterProps } from 'next/dist/client/with-router';
 import { GetStaticProps } from 'next';
+import Auth from '../../../components/Auth';
 
 interface Props extends WithRouterProps {
   root: string;
@@ -29,7 +30,11 @@ class MintNFTPage extends React.Component<Props> {
         direction="row"
       >
         <Box width="xlarge" >
-          <WithTinlake addresses={pool.addresses} contractConfig={pool.contractConfig} render={tinlake => <MintNFT tinlake={tinlake} />} />
+          <WithTinlake addresses={pool.addresses} contractConfig={pool.contractConfig} render={tinlake =>
+            <Auth tinlake={tinlake} render={() =>
+              <MintNFT tinlake={tinlake} />
+            } />
+          } />
         </Box>
       </Box>
     </ContainerWithFooter>;

--- a/pages/[root]/index.tsx
+++ b/pages/[root]/index.tsx
@@ -7,6 +7,7 @@ import { menuItems } from '../../menuItems';
 import config, { Pool as IPool } from '../../config';
 import { GetStaticProps } from 'next';
 import ContainerWithFooter from '../../components/ContainerWithFooter';
+import Auth from '../../components/Auth';
 
 interface Props {
   root: string;
@@ -24,7 +25,9 @@ class Pool extends React.Component <Props> {
         <Box justify="center" direction="row" >
           <Box width="xlarge">
             <WithTinlake addresses={pool.addresses} contractConfig={pool.contractConfig} render={tinlake =>
-              <Overview tinlake={tinlake} selectedPool={pool} />
+              <Auth tinlake={tinlake} render={() =>
+                <Overview tinlake={tinlake} selectedPool={pool} />
+              } />
             } />
           </Box>
         </Box>

--- a/pages/[root]/investments/investor.tsx
+++ b/pages/[root]/investments/investor.tsx
@@ -36,24 +36,23 @@ class InvestorPage extends React.Component<Props> {
       >
         <Box width="xlarge" >
           <WithTinlake addresses={pool.addresses} contractConfig={pool.contractConfig} render={tinlake =>
-            <Auth tinlake={tinlake}
-              render={auth =>
-                <Box>
-                  <SecondaryHeader>
+            <Auth tinlake={tinlake} render={auth =>
+              <Box>
+                <SecondaryHeader>
+                  <Box direction="row" gap="small" align="center">
+                    <BackLink href={'/investments'} />
                     <Box direction="row" gap="small" align="center">
-                      <BackLink href={'/investments'} />
-                      <Box direction="row" gap="small" align="center">
-                        <Heading level="3">Investor Details </Heading>
-                      </Box>
-                      <Box align="end">
-                          <Text style={{ color: '#808080' }}> address: {investorAddress}</Text>
-                      </Box>
-
+                      <Heading level="3">Investor Details </Heading>
                     </Box>
-                  </SecondaryHeader>
-                  <InvestorView investorAddress={investorAddress} tinlake={tinlake} auth={auth} />
-                </Box>
-              } />
+                    <Box align="end">
+                        <Text style={{ color: '#808080' }}> address: {investorAddress}</Text>
+                    </Box>
+
+                  </Box>
+                </SecondaryHeader>
+                <InvestorView investorAddress={investorAddress} tinlake={tinlake} auth={auth} />
+              </Box>
+            } />
           } />
         </Box>
       </Box>

--- a/pages/[root]/loans/index.tsx
+++ b/pages/[root]/loans/index.tsx
@@ -33,17 +33,16 @@ class LoanListPage extends React.Component<Props> {
       >
         <Box width="xlarge" gap="medium" >
           <WithTinlake addresses={pool.addresses} contractConfig={pool.contractConfig} render={tinlake =>
-              <Auth tinlake={tinlake}
-                render={auth =>
-                  <Box>
-                    <SecondaryHeader>
-                      <Heading level="3">Loans</Heading>
-                      <PoolLink href={'/loans/issue'}>
-                        <Button primary label="Open Loan" />
-                      </PoolLink>
-                    </SecondaryHeader>
-                    <LoanList tinlake={tinlake} auth={auth} />
-                  </Box>
+              <Auth tinlake={tinlake} render={auth =>
+                <Box>
+                  <SecondaryHeader>
+                    <Heading level="3">Loans</Heading>
+                    <PoolLink href={'/loans/issue'}>
+                      <Button primary label="Open Loan" />
+                    </PoolLink>
+                  </SecondaryHeader>
+                  <LoanList tinlake={tinlake} auth={auth} />
+                </Box>
               } />
           } />
         </Box>

--- a/pages/[root]/loans/issue.tsx
+++ b/pages/[root]/loans/issue.tsx
@@ -35,18 +35,17 @@ class LoanIssuePage extends React.Component<Props> {
       >
         <Box width="xlarge" >
           <WithTinlake addresses={pool.addresses} contractConfig={pool.contractConfig} render={tinlake =>
-            <Auth tinlake={tinlake}
-              render={auth =>
-                <Box>
-                  <SecondaryHeader>
-                    <Box direction="row" gap="small" align="center">
-                      <BackLink href={'/loans'} />
-                      <Heading level="3">Open Loan</Heading>
-                    </Box>
-                  </SecondaryHeader>
-                  <IssueLoan tinlake={tinlake} auth={auth} tokenId={tokenId} registry={registry}/>
-                </Box>
-              } />
+            <Auth tinlake={tinlake} render={auth =>
+              <Box>
+                <SecondaryHeader>
+                  <Box direction="row" gap="small" align="center">
+                    <BackLink href={'/loans'} />
+                    <Heading level="3">Open Loan</Heading>
+                  </Box>
+                </SecondaryHeader>
+                <IssueLoan tinlake={tinlake} auth={auth} tokenId={tokenId} registry={registry}/>
+              </Box>
+            } />
           } />
         </Box>
       </Box>

--- a/pages/[root]/loans/loan.tsx
+++ b/pages/[root]/loans/loan.tsx
@@ -42,8 +42,9 @@ class LoanPage extends React.Component<Props> {
             </Box>
           </SecondaryHeader>
           <WithTinlake addresses={pool.addresses} contractConfig={pool.contractConfig} render={tinlake =>
-            <Auth tinlake={tinlake}
-              render={auth => <Box>{loanId && <LoanView auth={auth} tinlake={tinlake} loanId={loanId} />}</Box>} />
+            <Auth tinlake={tinlake} render={auth =>
+              <Box>{loanId && <LoanView auth={auth} tinlake={tinlake} loanId={loanId} />}</Box>
+            } />
           } />
         </Box>
       </Box>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,8 +3,6 @@ import App from 'next/app';
 import { createWrapper } from 'next-redux-wrapper';
 import makeStore from '../utils/makeStore';
 import { AxisTheme } from '@centrifuge/axis-theme';
-import Auth from '../components/Auth';
-import WithTinlake from '../components/WithTinlake';
 import { StyledApp } from '../components/StyledApp';
 import Head from 'next/head';
 
@@ -24,11 +22,7 @@ class MyApp extends App {
           <title>Tinlake | Centrifuge | Decentralized Asset Financing</title>
         </Head>
         <StyledApp>
-          <WithTinlake render={tinlake =>
-            <Auth tinlake={tinlake} render={() =>
-              <Component {...pageProps} />
-            } />
-          } />
+          <Component {...pageProps} />
         </StyledApp>
       </AxisTheme >
     );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,14 +2,20 @@ import { Box } from 'grommet';
 import Header from '../components/Header';
 import Dashboard from '../containers/Dashboard';
 import ContainerWithFooter from '../components/ContainerWithFooter';
+import WithTinlake from '../components/WithTinlake';
+import Auth from '../components/Auth';
 
 function Home() {
   return (
     <ContainerWithFooter>
-      <Header selectedRoute={'/'} menuItems={[]} />
+      <Header selectedRoute={''} menuItems={[]} />
       <Box justify="center" direction="row" >
         <Box width="xlarge">
-          <Dashboard />
+          <WithTinlake render={tinlake =>
+            <Auth tinlake={tinlake} render={() =>
+              <Dashboard />
+            } />
+          } />
         </Box>
       </Box>
     </ContainerWithFooter>

--- a/services/tinlake/index.ts
+++ b/services/tinlake/index.ts
@@ -10,6 +10,7 @@ let currentAddresses: null | ContractAddresses = null;
 let currentContractConfig: null | any = null;
 
 export async function getTinlake({ addresses, contractConfig }: {addresses?: ContractAddresses | null, contractConfig?: any | null} = {}) {
+  console.log(`services/tinlake getTinlake({ addresses: ${JSON.stringify(addresses)}, contractConfig: ${JSON.stringify(contractConfig)}})`);
 
   if (tinlake === null) {
     const { transactionTimeout, rpcUrl } = config;
@@ -56,6 +57,8 @@ export async function getTinlake({ addresses, contractConfig }: {addresses?: Con
 }
 
 export async function authTinlake() {
+  console.log('services/tinlake authTinlake');
+
   if (!tinlake) { await getTinlake(); }
   if (authing || authed) { return; }
 


### PR DESCRIPTION
1. Remove state from `components/Auth`
2. Remove no longer needed wait functions `waitForAuthentication` and `waitForAuthorization` in Auth module
3. Remove duplicate Auth from _app.tsx
4. Parallelize loading of permissions to speed that process up
5. Fix header link to pool overview (did go to 404 before)
6. Refactor auth duck to be flatter by removing user entity – user's address depends on no pool data, proxies will and permissions do depend on pool data
7. Left `console.log`s in there by purpose to better debug our deployed environments